### PR TITLE
[ISACDEVIND-10] Dhyana 6060 binning management

### DIFF
--- a/src/Dhyana6060Camera.cpp
+++ b/src/Dhyana6060Camera.cpp
@@ -943,18 +943,31 @@ int Camera::getNbHwAcquiredFrames()
 void Camera::checkBin(Bin &hw_bin)
 {
 	DEB_MEMBER_FUNCT();
+	DEB_TRACE() << "checkBin";
 	//@BEGIN : check available values of binning H/V
-	std::vector<int> binningValues = {1, 2, 4};
 
 	int x = hw_bin.getX();
 	int y = hw_bin.getY();
-	if( !(std::find(binningValues.begin(), binningValues.end(), x) != binningValues.end() && 
-		std::find(binningValues.begin(), binningValues.end(), y) != binningValues.end()) ||
-		x != y)
-	{
-		DEB_ERROR() << "Binning values not supported.\n";
-		THROW_HW_ERROR(Error) << "Binning values not supported = " << DEB_VAR1(hw_bin);
-	}
+
+	#ifdef BINNING_6060_ENABLED
+		std::vector<int> binningValues = {1, 2, 4};
+
+		if( !(std::find(binningValues.begin(), binningValues.end(), x) != binningValues.end() && 
+			std::find(binningValues.begin(), binningValues.end(), y) != binningValues.end()) ||
+			x != y)
+		{
+			DEB_ERROR() << "Binning values not supported.\n";
+			THROW_HW_ERROR(Error) << "Binning values not supported = " << DEB_VAR1(hw_bin);
+		}
+
+	#else
+		if(x != 1 || y != 1)
+		{
+			DEB_ERROR() << "Binning values not supported";
+			THROW_HW_ERROR(Error) << "Binning values not supported = " << DEB_VAR1(hw_bin);
+		}
+
+	#endif
 	//@END
 
 	hw_bin = Bin(x, y);
@@ -967,34 +980,40 @@ void Camera::checkBin(Bin &hw_bin)
 void Camera::setBin(const Bin &set_bin)
 {
 	DEB_MEMBER_FUNCT();
+	DEB_TRACE() << "setBin";
 
-	TUCAMRET err;
-	TUCAM_ELEMENT node; // Property node
+	#ifdef BINNING_6060_ENABLED
 
-	if (m_bin != set_bin)
-	{	
-		node.pName = "Binning";
-		if (set_bin.getX() == 1 && set_bin.getY() == 1)
-		{
-			node.nVal = 0; //BinOff
-		}
-		else if (set_bin.getX() == 2 && set_bin.getY() == 2)
-		{
-			node.nVal = 1;	//Bin2x2Sum
-		}
-		else if (set_bin.getX() == 4 && set_bin.getY() == 4)
-		{
-			node.nVal = 2;	//Bin4x4Sum
-		}
-		
-		err = TUCAM_GenICam_SetElementValue(m_opCam.hIdxTUCam, &node);
-		if(TUCAMRET_SUCCESS != err)
-		{
-			THROW_HW_ERROR(Error) << "Unable to set Binning from the camera ! Error: " << err << " ";
-		}
+		TUCAMRET err;
+		TUCAM_ELEMENT node; // Property node
 
+		if (m_bin != set_bin)
+		{	
+			node.pName = "Binning";
+			if (set_bin.getX() == 1 && set_bin.getY() == 1)
+			{
+				node.nVal = 0; //BinOff
+			}
+			else if (set_bin.getX() == 2 && set_bin.getY() == 2)
+			{
+				node.nVal = 1;	//Bin2x2Sum
+			}
+			else if (set_bin.getX() == 4 && set_bin.getY() == 4)
+			{
+				node.nVal = 2;	//Bin4x4Sum
+			}
+			
+			err = TUCAM_GenICam_SetElementValue(m_opCam.hIdxTUCam, &node);
+			if(TUCAMRET_SUCCESS != err)
+			{
+				THROW_HW_ERROR(Error) << "Unable to set Binning from the camera ! Error: " << err << " ";
+			}
+
+			m_bin = set_bin;
+		}
+	#else
 		m_bin = set_bin;
-	}
+	#endif
 
 	DEB_RETURN() << DEB_VAR1(set_bin);
 }
@@ -1007,37 +1026,44 @@ void Camera::getBin(Bin &hw_bin)
 	DEB_MEMBER_FUNCT();
 	//@BEGIN : get binning from Driver/API
 
-	TUCAM_ELEMENT node; // Property node
 	int x, y;
 
-	// Get Binning
-	int err = TUCAM_GenICam_ElementAttr(m_opCam.hIdxTUCam, &node, "Binning");
-	if(TUCAMRET_SUCCESS != err)
-	{
-		THROW_HW_ERROR(Error) << "Unable to Read BinningHorizontal from the camera ! Error: " << err << " ";
-	}
+	#ifdef BINNING_6060_ENABLED
 
-	switch (node.nVal)
-	{
-		case 0:
-			x = 2;
-			y = 2;
-			break;
-		case 0:
-			x = 4;
-			y = 4;
-			break;
-		case 0:
-		default:
-			x = 1;
-			y = 1;
-			break;
-	}
+		TUCAM_ELEMENT node; // Property node
 
-	Bin tmp_bin(x, y);
+		// Get Binning
+		int err = TUCAM_GenICam_ElementAttr(m_opCam.hIdxTUCam, &node, "Binning");
+		if(TUCAMRET_SUCCESS != err)
+		{
+			THROW_HW_ERROR(Error) << "Unable to Read BinningHorizontal from the camera ! Error: " << err << " ";
+		}
+
+		switch (node.nVal)
+		{
+			case 0:
+				x = 2;
+				y = 2;
+				break;
+			case 0:
+				x = 4;
+				y = 4;
+				break;
+			case 0:
+			default:
+				x = 1;
+				y = 1;
+				break;
+		}
+
+	#else
+		x = 1;
+		y = 1;
+	#endif
 
 	//@END
 
+	Bin tmp_bin(x, y);
 	hw_bin = tmp_bin;
 	m_bin = tmp_bin;
 

--- a/src/Dhyana6060Camera.cpp
+++ b/src/Dhyana6060Camera.cpp
@@ -944,11 +944,15 @@ void Camera::checkBin(Bin &hw_bin)
 {
 	DEB_MEMBER_FUNCT();
 	//@BEGIN : check available values of binning H/V
+	std::vector<int> binningValues = {1, 2, 4};
+
 	int x = hw_bin.getX();
 	int y = hw_bin.getY();
-	if(x != 1 || y != 1)
+	if( !(std::find(binningValues.begin(), binningValues.end(), x) != binningValues.end() && 
+		std::find(binningValues.begin(), binningValues.end(), y) != binningValues.end()) ||
+		x != y)
 	{
-		DEB_ERROR() << "Binning values not supported";
+		DEB_ERROR() << "Binning values not supported.\n";
 		THROW_HW_ERROR(Error) << "Binning values not supported = " << DEB_VAR1(hw_bin);
 	}
 	//@END
@@ -956,13 +960,41 @@ void Camera::checkBin(Bin &hw_bin)
 	hw_bin = Bin(x, y);
 	DEB_RETURN() << DEB_VAR1(hw_bin);
 }
+
 //-----------------------------------------------------
 // @brief set the new binning mode
 //-----------------------------------------------------
 void Camera::setBin(const Bin &set_bin)
 {
 	DEB_MEMBER_FUNCT();
-	m_bin = set_bin;
+
+	TUCAMRET err;
+	TUCAM_ELEMENT node; // Property node
+
+	if (m_bin != set_bin)
+	{	
+		node.pName = "Binning";
+		if (set_bin.getX() == 1 && set_bin.getY() == 1)
+		{
+			node.nVal = 0; //BinOff
+		}
+		else if (set_bin.getX() == 2 && set_bin.getY() == 2)
+		{
+			node.nVal = 1;	//Bin2x2Sum
+		}
+		else if (set_bin.getX() == 4 && set_bin.getY() == 4)
+		{
+			node.nVal = 2;	//Bin4x4Sum
+		}
+		
+		err = TUCAM_GenICam_SetElementValue(m_opCam.hIdxTUCam, &node);
+		if(TUCAMRET_SUCCESS != err)
+		{
+			THROW_HW_ERROR(Error) << "Unable to set Binning from the camera ! Error: " << err << " ";
+		}
+
+		m_bin = set_bin;
+	}
 
 	DEB_RETURN() << DEB_VAR1(set_bin);
 }
@@ -974,10 +1006,37 @@ void Camera::getBin(Bin &hw_bin)
 {
 	DEB_MEMBER_FUNCT();
 	//@BEGIN : get binning from Driver/API
-	int bin_x = 1;
-	int bin_y = 1;
+
+	TUCAM_ELEMENT node; // Property node
+	int x, y;
+
+	// Get Binning
+	int err = TUCAM_GenICam_ElementAttr(m_opCam.hIdxTUCam, &node, "Binning");
+	if(TUCAMRET_SUCCESS != err)
+	{
+		THROW_HW_ERROR(Error) << "Unable to Read BinningHorizontal from the camera ! Error: " << err << " ";
+	}
+
+	switch (node.nVal)
+	{
+		case 0:
+			x = 2;
+			y = 2;
+			break;
+		case 0:
+			x = 4;
+			y = 4;
+			break;
+		case 0:
+		default:
+			x = 1;
+			y = 1;
+			break;
+	}
+
+	Bin tmp_bin(x, y);
+
 	//@END
-	Bin tmp_bin(bin_x, bin_y);
 
 	hw_bin = tmp_bin;
 	m_bin = tmp_bin;


### PR DESCRIPTION
Implemented binning management for Dhyana 6060 cameras.

Due to several bugs with Roi management in Lima, the binning management has been disabled with a #ifdef statement.
To enable the binning, compile with flag BINNING_6060_ENABLED.
